### PR TITLE
Be explicit with restyled `stylish-haskell` files

### DIFF
--- a/.restyled.yaml
+++ b/.restyled.yaml
@@ -1,0 +1,4 @@
+---
+- stylish-haskell:
+    include:
+      - '**/*.hs'

--- a/.restyled.yaml
+++ b/.restyled.yaml
@@ -1,4 +1,9 @@
 ---
-- stylish-haskell:
-    include:
-      - '**/*.hs'
+auto: false
+enabled: true
+remote_files: []
+restylers:
+  - stylish-haskell:
+      include:
+        - '**/*.hs'
+statuses: true


### PR DESCRIPTION
It seems like it's not picking up the `lib` directory.
But also, we want every Haskell file to be picked up.